### PR TITLE
Changes necessary to run scheduler in docker (and kubernetes)

### DIFF
--- a/enterprise_scheduler/scheduler_application.py
+++ b/enterprise_scheduler/scheduler_application.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Jupyter Enterprise Scheduler - Schedule Notebook execution."""
+import os
 import sys
 
 import asyncio
@@ -11,13 +12,15 @@ from flask_restful import Api
 from enterprise_scheduler.scheduler_resource import SchedulerResource
 from enterprise_scheduler.util import fix_asyncio_event_loop_policy
 
+server_name = os.getenv('SERVER_NAME','127.0.0.1:5000')
+
 @click.command()
 @click.option('--gateway_host', default='lresende-elyra:8888', help='Jupyter Enterprise Gateway host information')
 @click.option('--kernelspec', default='python2', help='Jupyter Notebook kernelspec to use while executing notebook')
 def main(gateway_host, kernelspec):
     """Jupyter Enterprise Scheduler - Schedule Notebook execution."""
-    click.echo('Starting Scheduler at {} using {} default kernelspec'.format(gateway_host, kernelspec))
-    click.echo('Add new tasks via post commands to http://localhost:5000/scheduler/tasks ')
+    click.echo('Starting Scheduler at {} using Gateway at {} with default kernelspec {}'.format(server_name, gateway_host, kernelspec))
+    click.echo('Add new tasks via post commands to http://{}/scheduler/tasks '.format(server_name))
 
     fix_asyncio_event_loop_policy(asyncio)
 
@@ -27,9 +30,11 @@ def main(gateway_host, kernelspec):
     api.add_resource(SchedulerResource, '/scheduler/tasks',
                      resource_class_kwargs={ 'default_gateway_host': gateway_host, 'default_kernelspec': kernelspec })
 
-    print('Add new tasks via http://localhost:5000/scheduler/tasks ')
+    print('Add new tasks via http://{}/scheduler/tasks '.format(server_name))
 
-    app.run(debug=True, use_reloader=False)
+    server_parts = server_name.split(':')
+
+    app.run(host=server_parts[0], port=int(server_parts[1]), debug=True, use_reloader=False)
 
     return 0
 

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM jupyter/minimal-notebook
+
+# minimal-notebook leaves user as jovyan
+USER root
+
+COPY enterprise_scheduler*.whl /tmp
+RUN pip install /tmp/enterprise_scheduler*.whl && \
+	rm -f /tmp/enterprise_scheduler*.whl 
+
+COPY bootstrap-enterprise-scheduler.sh /etc/bootstrap-enterprise-scheduler.sh
+RUN chown root.root /etc/bootstrap-enterprise-scheduler.sh && \
+	chmod 0755 /etc/bootstrap-enterprise-scheduler.sh
+
+CMD ["/etc/bootstrap-enterprise-scheduler.sh"]
+
+USER jovyan
+

--- a/etc/docker/bootstrap-enterprise-scheduler.sh
+++ b/etc/docker/bootstrap-enterprise-scheduler.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+server_name=${EGS_SCHEDULER_HOST:-"0.0.0.0:5000"}
+gateway_host=${EGS_GATEWAY_HOST:-"localhost:8888"}
+kernelspec=${EGS_KERNELSPEC:-"python_tf_kubernetes"}
+
+# Flask host and port can be overridden using SERVER_NAME
+export SERVER_NAME=${server_name}
+
+enterprise_scheduler --gateway_host ${gateway_host} --kernelspec ${kernelspec}
+exit $?

--- a/etc/docker/enterprise-scheduler.yaml
+++ b/etc/docker/enterprise-scheduler.yaml
@@ -1,0 +1,53 @@
+# This file defines the Kubernetes objects necessary for Enterprise Scheduler to run witihin Kubernetes.
+#
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: enterprise-gateway
+    component: enterprise-scheduler
+  name: enterprise-scheduler
+spec:
+  ports:
+  - name: http
+    port: 5000
+    targetPort: 5000
+  selector:
+    scheduler-selector: enterprise-scheduler
+  sessionAffinity: ClientIP
+  type: NodePort
+  externalIPs:
+  - 9.30.118.200
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: enterprise-scheduler
+  labels:
+    scheduler-selector: enterprise-scheduler
+    app: enterprise-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      scheduler-selector: enterprise-scheduler
+  template:
+    metadata:
+      labels:
+        scheduler-selector: enterprise-scheduler
+        app: enterprise-gateway
+        component: enterprise-scheduler
+    spec:
+      containers:
+      - env:
+        - name: EGS_SCHEDULER_HOST
+          value: "0.0.0.0:5000"
+        - name: EGS_GATEWAY_HOST
+          value: "enterprise-gateway.default.svc.cluster.local:8888"
+        - name: EGS_KERNELSPECS
+          value: "python_tf_kubernetes"
+        image: elyra/enterprise-scheduler:dev
+        name: enterprise-scheduler
+        ports:
+        - containerPort: 5000


### PR DESCRIPTION
- Modify Makefile to include docker image creation targets (and clean up others relative to dependencies)
- Add `Dockerfile` and startup script with support for environment variables to transfer to command line
- Add kubernetes yaml file to create service and deployment
- Modify scheduler application to allow for different host and port values