### PR TITLE
Added handling for failed FFDL calls

### DIFF
--- a/enterprise_scheduler/executor.py
+++ b/enterprise_scheduler/executor.py
@@ -100,9 +100,15 @@ class FfDLExecutor(Executor):
 
             result = client.post('/models', **files)
 
-            print("Training URL : http://{}:{}/#/trainings/{}/show".format(urlparse(config.api_endpoint).netloc.split(":")[0],
-                                                                      ffdl_ui_port,
-                                                                      result['model_id']))
+            if 'models' not in result:
+                print("FFDL Job Submission Request Failed: {}".format(result['message']))
+            elif result['models']:
+                print("Training URL : http://{}:{}/#/trainings/{}/show"
+                      .format(urlparse(config.api_endpoint).netloc.split(":")[0],
+                              ffdl_ui_port,
+                              result['model_id']))
+            else:
+                print("FFDL Job Submission Failed")
         except requests.exceptions.Timeout:
             print("FFDL Job Submission Request Timed Out....")
         except requests.exceptions.TooManyRedirects:


### PR DESCRIPTION
When making calls to FFDL currently there is only error handling for errors in the request, not for returned content.

I added handling for cases where the call returns a error message (usually a malformed form) and for when the returned model list is empty, signifying the job submission failed on the FFDL side.