### PR TITLE
Support configuring parameters during notebook submission

### DIFF
--- a/enterprise_scheduler/executor.py
+++ b/enterprise_scheduler/executor.py
@@ -186,13 +186,11 @@ class FfDLExecutor(Executor):
 
     def _create_env_sh(self, task, task_directory):
         lines = ["#!/usr/bin/env bash\n"]
-        print(task['env'])
         for key, value in task['env'].items():
             lines.append("export {}={}".format(shlex.quote(key),
                                                shlex.quote(value)))
 
         contents = "\n".join(lines) + "\n"
-        print(contents)
         self._write_file(task_directory, "env.sh", contents)
 
     @staticmethod

--- a/enterprise_scheduler/executor.py
+++ b/enterprise_scheduler/executor.py
@@ -135,10 +135,10 @@ class FfDLExecutor(Executor):
                 id='sl-internal-os',
                 type='mount_cos',
                 training_data= dict(
-                    container=task['cos_bucket']
+                    container=task['cos_bucket_in']
                 ),
                 training_results= dict(
-                    container=task['cos_bucket']
+                    container=task['cos_bucket_out']
                 ),
                 connection= dict(
                     auth_url=task['cos_endpoint'],

--- a/enterprise_scheduler/resources/ffdl/start.sh
+++ b/enterprise_scheduler/resources/ffdl/start.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -x
 
 pip install --upgrade pip
 pip install --upgrade ipykernel
@@ -8,5 +9,8 @@ pip install --upgrade papermill
 
 echo "Available Jupyter kernels..."
 jupyter kernelspec list
+
+echo "Configuring env..."
+source ./env.sh
 
 ./run_notebook.py


### PR DESCRIPTION
Sister PR of lresende/enterprise_scheduler_extension#5

- Makes the cos bucket configurable
- Sets (escaped) env vars passed from the submission